### PR TITLE
Update 'go get' command to actually install the binary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and has some build problems.
 I wrote this is so that Apache Cassandra users can see if ssTables are being
 cached. If $GOPATH/bin is in your PATH, this will get it installed:
 
-    go get github.com/tobert/pcstat
+    go get github.com/tobert/pcstat/pcstat
     pcstat /var/lib/cassandra/data/*/*/*-Data.db
 
 If you don't want to mess around with building the software, binaries are provided


### PR DESCRIPTION
The previous 'go get' command stopped working when pcstat was moved
into its own directory.

Alternatively one could use 'go get github.com/tobert/pcstat/...'
to install all subdirectories.