### PR TITLE
skip could not mmap error when file size is 0

### DIFF
--- a/mincore.go
+++ b/mincore.go
@@ -26,6 +26,10 @@ import (
 // mmap the given file, get the mincore vector, then
 // return it as an []bool
 func FileMincore(f *os.File, size int64) ([]bool, error) {
+        //skip could not mmap error when the file size is 0
+        if int(size) == 0 {
+           return nil, nil
+        }
 	// mmap is a []byte
 	mmap, err := syscall.Mmap(int(f.Fd()), 0, int(size), syscall.PROT_NONE, syscall.MAP_SHARED)
 	if err != nil {


### PR DESCRIPTION
skip the "could not mmap" error when file size is 0