### PR TITLE
Switches from syscall to golang.org/x/sys/unix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ and has some build problems.
 I wrote this is so that Apache Cassandra users can see if ssTables are being
 cached. If $GOPATH/bin is in your PATH, this will get it installed:
 
+    go get golang.org/x/sys/unix
     go get github.com/tobert/pcstat/pcstat
     pcstat /var/lib/cassandra/data/*/*/*-Data.db
 

--- a/mnt_ns_linux.go
+++ b/mnt_ns_linux.go
@@ -22,7 +22,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // not available before Go 1.4
@@ -62,7 +63,7 @@ func getMountNs(pid int) int {
 }
 
 func setns(fd int) error {
-	ret, _, err := syscall.Syscall(SYS_SETNS, uintptr(uint(fd)), uintptr(CLONE_NEWNS), 0)
+	ret, _, err := unix.Syscall(SYS_SETNS, uintptr(uint(fd)), uintptr(CLONE_NEWNS), 0)
 	if ret != 0 {
 		return fmt.Errorf("syscall SYS_SETNS failed: %v", err)
 	}

--- a/pcstat/winsize.go
+++ b/pcstat/winsize.go
@@ -26,6 +26,8 @@ import (
 	"log"
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 // adapted from https://groups.google.com/d/msg/golang-nuts/8d4pOPmSL9Q/H6WUqbGNELEJ
@@ -36,7 +38,7 @@ type winsize struct {
 
 func getwinsize() winsize {
 	ws := winsize{}
-	_, _, err := syscall.Syscall(syscall.SYS_IOCTL,
+	_, _, err := unix.Syscall(syscall.SYS_IOCTL,
 		uintptr(0), uintptr(syscall.TIOCGWINSZ),
 		uintptr(unsafe.Pointer(&ws)))
 	if err != 0 {


### PR DESCRIPTION
According to
https://golang.org/pkg/syscall/
and
https://docs.google.com/document/d/1QXzI9I1pOfZPujQzxhyRy6EeHYTQitKKjHfpq0zpxZs/edit
the syscall library is essentially deprecated
moving forward with go 1.4.

"NOTE: This package is locked down. Code outside
the standard Go repository should be migrated to
use the corresponding package in the go.sys
subrepository. That is also where updates
required by new systems or versions should be
applied."