### PR TITLE
add -top

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ pcstat <-json <-pps>|-terse|-default> <-nohdr> <-bname> file file file
  -bname use basename(file) in the output (use for long paths)
  -plain return data with no box characters
  -unicode return data with unicode box characters
-
+ -pid int show all open maps for the given pid
+ -top int show top x cached files
 ```
 
 ## Examples

--- a/pcstat/formats.go
+++ b/pcstat/formats.go
@@ -34,15 +34,14 @@ import (
 
 type PcStatusList []pcstat.PcStatus
 
-
 func (a PcStatusList) Len() int {
-    return len(a)
+	return len(a)
 }
-func (a PcStatusList) Swap(i, j int){
-    a[i], a[j] = a[j], a[i]
+func (a PcStatusList) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
 }
 func (a PcStatusList) Less(i, j int) bool {
-    return a[j].Cached < a[i].Cached
+	return a[j].Cached < a[i].Cached
 }
 
 func (stats PcStatusList) formatUnicode() {

--- a/pcstat/formats.go
+++ b/pcstat/formats.go
@@ -34,6 +34,17 @@ import (
 
 type PcStatusList []pcstat.PcStatus
 
+
+func (a PcStatusList) Len() int {
+    return len(a)
+}
+func (a PcStatusList) Swap(i, j int){
+    a[i], a[j] = a[j], a[i]
+}
+func (a PcStatusList) Less(i, j int) bool {
+    return a[j].Cached < a[i].Cached
+}
+
 func (stats PcStatusList) formatUnicode() {
 	maxName := stats.maxNameLen()
 

--- a/pcstat/main.go
+++ b/pcstat/main.go
@@ -56,17 +56,17 @@ func init() {
 }
 
 func uniqueSlice(slice *[]string) {
-    found := make(map[string]bool)
-    total := 0
-    for i, val := range *slice {
-        if _, ok := found[val]; !ok {
-            found[val] = true
-            (*slice)[total] = (*slice)[i]
-            total++
-        }
-    }
+	found := make(map[string]bool)
+	total := 0
+	for i, val := range *slice {
+		if _, ok := found[val]; !ok {
+			found[val] = true
+			(*slice)[total] = (*slice)[i]
+			total++
+		}
+	}
 
-    *slice = (*slice)[:total]
+	*slice = (*slice)[:total]
 }
 
 func getStatsFromFiles(files []string) PcStatusList {
@@ -138,8 +138,11 @@ func top(top int) {
 	stats := getStatsFromFiles(files)
 
 	sort.Sort(PcStatusList(stats))
-	topStats := stats[:top]
-	formatStats(topStats)
+
+	if len(stats) > top {
+		stats = stats[:top]
+	}
+	formatStats(stats)
 }
 
 func main() {

--- a/pcstat/main.go
+++ b/pcstat/main.go
@@ -30,12 +30,13 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sort"
 
 	"github.com/tobert/pcstat"
 )
 
 var (
-	pidFlag                                     int
+	pidFlag, topFlag                            int
 	terseFlag, nohdrFlag, jsonFlag, unicodeFlag bool
 	plainFlag, ppsFlag, histoFlag, bnameFlag    bool
 )
@@ -43,6 +44,7 @@ var (
 func init() {
 	// TODO: error on useless/broken combinations
 	flag.IntVar(&pidFlag, "pid", 0, "show all open maps for the given pid")
+	flag.IntVar(&topFlag, "top", 0, "show top x cached files")
 	flag.BoolVar(&terseFlag, "terse", false, "show terse output")
 	flag.BoolVar(&nohdrFlag, "nohdr", false, "omit the header from terse & text output")
 	flag.BoolVar(&jsonFlag, "json", false, "return data in JSON format")
@@ -53,23 +55,21 @@ func init() {
 	flag.BoolVar(&bnameFlag, "bname", false, "convert paths to basename to narrow the output")
 }
 
-func main() {
-	flag.Parse()
-	files := flag.Args()
+func uniqueSlice(slice *[]string) {
+    found := make(map[string]bool)
+    total := 0
+    for i, val := range *slice {
+        if _, ok := found[val]; !ok {
+            found[val] = true
+            (*slice)[total] = (*slice)[i]
+            total++
+        }
+    }
 
-	if pidFlag != 0 {
-		pcstat.SwitchMountNs(pidFlag)
-		maps := getPidMaps(pidFlag)
-		files = append(files, maps...)
-	}
+    *slice = (*slice)[:total]
+}
 
-	// all non-flag arguments are considered to be filenames
-	// this works well with shell globbing
-	// file order is preserved throughout this program
-	if len(files) == 0 {
-		flag.Usage()
-		os.Exit(1)
-	}
+func getStatsFromFiles(files []string) PcStatusList {
 
 	stats := make(PcStatusList, 0, len(files))
 	for _, fname := range files {
@@ -88,7 +88,10 @@ func main() {
 
 		stats = append(stats, status)
 	}
+	return stats
+}
 
+func formatStats(stats PcStatusList) {
 	if jsonFlag {
 		stats.formatJson(!ppsFlag)
 	} else if terseFlag {
@@ -102,6 +105,68 @@ func main() {
 	} else {
 		stats.formatText()
 	}
+}
+
+func top(top int) {
+	p, err := Processes()
+	if err != nil {
+		log.Fatalf("err: %s", err)
+	}
+
+	if len(p) <= 0 {
+		log.Fatal("Cannot find any process.")
+	}
+
+	results := make([]Process, 0, 50)
+
+	for _, p1 := range p {
+		if p1.RSS() != 0 {
+			results = append(results, p1)
+		}
+	}
+
+	var files []string
+
+	for _, process := range results {
+		pcstat.SwitchMountNs(process.Pid())
+		maps := getPidMaps(process.Pid())
+		files = append(files, maps...)
+	}
+
+	uniqueSlice(&files)
+
+	stats := getStatsFromFiles(files)
+
+	sort.Sort(PcStatusList(stats))
+	topStats := stats[:top]
+	formatStats(topStats)
+}
+
+func main() {
+	flag.Parse()
+
+	if topFlag != 0 {
+		top(topFlag)
+		os.Exit(0)
+	}
+
+	files := flag.Args()
+	if pidFlag != 0 {
+		pcstat.SwitchMountNs(pidFlag)
+		maps := getPidMaps(pidFlag)
+		files = append(files, maps...)
+	}
+
+	// all non-flag arguments are considered to be filenames
+	// this works well with shell globbing
+	// file order is preserved throughout this program
+	if len(files) == 0 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	stats := getStatsFromFiles(files)
+	formatStats(stats)
 }
 
 func getPidMaps(pid int) []string {

--- a/pcstat/process.go
+++ b/pcstat/process.go
@@ -1,0 +1,54 @@
+// ps provides an API for finding and listing processes in a platform-agnostic
+// way.
+//
+// NOTE: If you're reading these docs online via GoDocs or some other system,
+// you might only see the Unix docs. This project makes heavy use of
+// platform-specific implementations. We recommend reading the source if you
+// are interested.
+package main
+
+// Process is the generic interface that is implemented on every platform
+// and provides common operations for processes.
+type Process interface {
+	// Pid is the process ID for this process.
+	Pid() int
+
+	// PPid is the parent process ID for this process.
+	PPid() int
+
+	RSS() int
+
+	// Executable name running this process. This is not a path to the
+	// executable.
+	Executable() string
+}
+
+type ProcessSlice [] Process
+
+func (a ProcessSlice) Len() int {
+    return len(a)
+}
+func (a ProcessSlice) Swap(i, j int){
+    a[i], a[j] = a[j], a[i]
+}
+func (a ProcessSlice) Less(i, j int) bool {
+    return a[j].RSS() < a[i].RSS()
+}
+
+// Processes returns all processes.
+//
+// This of course will be a point-in-time snapshot of when this method was
+// called. Some operating systems don't provide snapshot capability of the
+// process table, in which case the process table returned might contain
+// ephemeral entities that happened to be running when this was called.
+func Processes() ([]Process, error) {
+	return processes()
+}
+
+// FindProcess looks up a single process by pid.
+//
+// Process will be nil and error will be nil if a matching process is
+// not found.
+func FindProcess(pid int) (Process, error) {
+	return findProcess(pid)
+}

--- a/pcstat/process.go
+++ b/pcstat/process.go
@@ -23,16 +23,16 @@ type Process interface {
 	Executable() string
 }
 
-type ProcessSlice [] Process
+type ProcessSlice []Process
 
 func (a ProcessSlice) Len() int {
-    return len(a)
+	return len(a)
 }
-func (a ProcessSlice) Swap(i, j int){
-    a[i], a[j] = a[j], a[i]
+func (a ProcessSlice) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
 }
 func (a ProcessSlice) Less(i, j int) bool {
-    return a[j].RSS() < a[i].RSS()
+	return a[j].RSS() < a[i].RSS()
 }
 
 // Processes returns all processes.

--- a/pcstat/process_linux.go
+++ b/pcstat/process_linux.go
@@ -1,0 +1,40 @@
+// +build linux
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"strconv"
+)
+
+// Refresh reloads all the data associated with this process.
+func (p *UnixProcess) Refresh() error {
+	statPath := fmt.Sprintf("/proc/%d/stat", p.pid)
+	dataBytes, err := ioutil.ReadFile(statPath)
+	if err != nil {
+		return err
+	}
+
+	// First, parse out the image name
+	data := string(dataBytes)
+	binStart := strings.IndexRune(data, '(') + 1
+	binEnd := strings.IndexRune(data[binStart:], ')')
+	p.binary = data[binStart : binStart+binEnd]
+
+	stats := strings.Split(data, " ")
+	// http://man7.org/linux/man-pages/man5/proc.5.html
+	p.rss, err = strconv.Atoi(stats[23])
+
+	// Move past the image name and start parsing the rest
+	data = data[binStart+binEnd+2:]
+	_, err = fmt.Sscanf(data,
+		"%c %d %d %d",
+		&p.state,
+		&p.ppid,
+		&p.pgrp,
+		&p.sid)
+
+	return err
+}

--- a/pcstat/process_unix.go
+++ b/pcstat/process_unix.go
@@ -1,0 +1,107 @@
+// +build linux solaris
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+)
+
+// UnixProcess is an implementation of Process that contains Unix-specific
+// fields and information.
+type UnixProcess struct {
+	pid   int
+	ppid  int
+	state rune
+	pgrp  int
+	sid   int
+	rss   int
+
+	binary string
+}
+
+func (p *UnixProcess) Pid() int {
+	return p.pid
+}
+
+func (p *UnixProcess) PPid() int {
+	return p.ppid
+}
+
+
+func (p *UnixProcess) RSS() int {
+	return p.rss
+}
+
+func (p *UnixProcess) Executable() string {
+	return p.binary
+}
+
+func findProcess(pid int) (Process, error) {
+	dir := fmt.Sprintf("/proc/%d", pid)
+	_, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return newUnixProcess(pid)
+}
+
+func processes() ([]Process, error) {
+	d, err := os.Open("/proc")
+	if err != nil {
+		return nil, err
+	}
+	defer d.Close()
+
+	results := make([]Process, 0, 50)
+	for {
+		fis, err := d.Readdir(10)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		for _, fi := range fis {
+			// We only care about directories, since all pids are dirs
+			if !fi.IsDir() {
+				continue
+			}
+
+			// We only care if the name starts with a numeric
+			name := fi.Name()
+			if name[0] < '0' || name[0] > '9' {
+				continue
+			}
+
+			// From this point forward, any errors we just ignore, because
+			// it might simply be that the process doesn't exist anymore.
+			pid, err := strconv.ParseInt(name, 10, 0)
+			if err != nil {
+				continue
+			}
+
+			p, err := newUnixProcess(int(pid))
+			if err != nil {
+				continue
+			}
+
+			results = append(results, p)
+		}
+	}
+
+	return results, nil
+}
+
+func newUnixProcess(pid int) (*UnixProcess, error) {
+	p := &UnixProcess{pid: pid}
+	return p, p.Refresh()
+}

--- a/pcstat/process_unix.go
+++ b/pcstat/process_unix.go
@@ -30,7 +30,6 @@ func (p *UnixProcess) PPid() int {
 	return p.ppid
 }
 
-
 func (p *UnixProcess) RSS() int {
 	return p.rss
 }


### PR DESCRIPTION
#16 

Add a new param --top to pcstat, it reads the /proc/[pid]/stat files, and finds those processes who's rss is not 0, then collects all the files opened by those processes, gets stats and sort them by cached pages.

Here is an example:

```
$ sudo pcstat --top 3  --bname  
+-------------+----------------+------------+-----------+---------+
| Name        | Size (bytes)   | Pages      | Cached    | Percent |
|-------------+----------------+------------+-----------+---------|
| chrome      | 114911208      | 28055      | 25476     | 090.807 |
| pycharm.jar | 95177431       | 23237      | 11479     | 049.400 |
| atom        | 62641344       | 15294      | 10578     | 069.164 |
+-------------+----------------+------------+-----------+---------+
```