### PR TITLE
README and dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and has some build problems.
 I wrote this is so that Apache Cassandra users can see if ssTables are being
 cached. If $GOPATH/bin is in your PATH, this will get it installed:
 
-    go install github.com/tobert/pcstat/pcstat@latest
+    go install github.com/tobert/pcstat@latest
     pcstat /var/lib/cassandra/data/*/*/*-Data.db
 
 If you don't want to mess around with building the software, binaries are provided

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ atobey@brak ~/src/pcstat $ ./pcstat testfile
 
 ## Requirements
 
-Go 1.4 or higher and golang.org/x/sys/unix.
+Go 1.17 or higher.
 
 From the mincore(2) man page:
 
@@ -179,7 +179,7 @@ From the mincore(2) man page:
 
 ## Author
 
-A. Tobey <tobert@gmail.com> @MissAmyTobey
+A. Tobey <tobert@gmail.com> @renice@hachyderm.io
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ and has some build problems.
 I wrote this is so that Apache Cassandra users can see if ssTables are being
 cached. If $GOPATH/bin is in your PATH, this will get it installed:
 
-    go get golang.org/x/sys/unix
-    go get github.com/tobert/pcstat/pcstat
+    go install github.com/tobert/pcstat/pcstat@latest
     pcstat /var/lib/cassandra/data/*/*/*-Data.db
 
 If you don't want to mess around with building the software, binaries are provided

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/tobert/pcstat
 
-go 1.13
+go 1.17
 
-require golang.org/x/sys v0.0.0-20210917161153-d61c044b1678
+require golang.org/x/sys v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 h1:J27LZFQBFoihqXoegpscI10HpjZ7B5WQLLKL2FZXQKw=
-golang.org/x/sys v0.0.0-20210917161153-d61c044b1678/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
I got a report that installs aren't working and it's because the `go get` instructions haven't been updated since go 1.13 timeframe. So that's fixed.

Also x/sys was very old and it's updated to latest. It requires go 1.17 so pcstat does now too.