### PR TITLE
fixed setns system call error

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,14 +32,14 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/tobert/pcstat/pkg"
+	pcstat "github.com/tobert/pcstat/pkg"
 )
 
 var (
 	pidFlag                                     int
 	terseFlag, nohdrFlag, jsonFlag, unicodeFlag bool
 	plainFlag, ppsFlag, histoFlag, bnameFlag    bool
-	sortFlag bool
+	sortFlag                                    bool
 )
 
 func init() {
@@ -61,9 +61,9 @@ func main() {
 	files := flag.Args()
 
 	if pidFlag != 0 {
-		pcstat.SwitchMountNs(pidFlag)
 		maps := getPidMaps(pidFlag)
 		files = append(files, maps...)
+		pcstat.SwitchMountNs(pidFlag)
 	}
 
 	// all non-flag arguments are considered to be filenames

--- a/pkg/mnt_ns_linux.go
+++ b/pkg/mnt_ns_linux.go
@@ -22,13 +22,9 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"golang.org/x/sys/unix"
 )
-
-// not available before Go 1.4
-const CLONE_NEWNS = 0x00020000 /* mount namespace */
 
 // if the pid is in a different mount namespace (e.g. Docker)
 // the paths will be all wrong, so try to enter that namespace
@@ -75,7 +71,7 @@ func setns(fd int) error {
 	}
 
 	defer nsMountFile.Close()
-	if err = unix.Setns(int(nsMountFile.Fd()), syscall.CLONE_NEWNS); err != nil {
+	if err = unix.Setns(int(nsMountFile.Fd()), unix.CLONE_NEWNS); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
The first parameter fd of the setns system call should refers to a /proc/[pid]/ns/ link. setns fails, then cannot get the page cache for a containerized process.