### PR TITLE
Add support for cachestat syscall as mincore alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Command-line arguments are described below. Every argument following the program
 flags is considered a file for inspection.
 
 ```
-pcstat <-json <-pps>|-terse|-default> <-nohdr> <-bname> file file file
+pcstat <-json <-pps>|-terse|-default> <-nohdr> <-bname> <-cachestat> file file file
  -json output will be JSON
    -pps include the per-page information in the output (can be huge!)
  -terse print terse machine-parseable output
@@ -40,7 +40,7 @@ pcstat <-json <-pps>|-terse|-default> <-nohdr> <-bname> file file file
  -bname use basename(file) in the output (use for long paths)
  -plain return data with no box characters
  -unicode return data with unicode box characters
-
+ -cachestat use new cachestat syscall instead of mincore (kernel 6.5+, x86_64 only)
 ```
 
 ## Examples
@@ -99,6 +99,30 @@ atobey@brak ~ $ pcstat -json testfile3 |json_pp
    "uncached":  24941,
    "percent":   0.23999040038398464,
    "status":    []
+ }
+]
+```
+
+The extra statistics from the `-cachestat` option (kernel 6.5+) are only 
+included in the JSON output for now.
+
+```
+atobey@brak ~ $ pcstat -json -cachestat testfile3 |json_pp
+[
+ {
+   "filename":         "testfile3",
+   "size":             102401024,
+   "timestamp":        "2024-05-22T13:57:19.971348936Z",
+   "mtime":            "2024-05-22T12:20:47.940163295Z",
+   "pages":            25001,
+   "cached":           60,
+   "uncached":         24941,
+   "percent":          0.23999040038398464,
+   "status":           []
+   "dirty":            22,
+   "writeback":        38,
+   "evicted":          24941,
+   "recently_evicted": 24941
  }
 ]
 ```
@@ -169,13 +193,16 @@ atobey@brak ~/src/pcstat $ ./pcstat testfile
 
 ## Requirements
 
-Go 1.17 or higher.
+Go 1.18 or higher.
 
 From the mincore(2) man page:
 
 * Available since Linux 2.3.99pre1 and glibc 2.2.
 * mincore() is not specified in POSIX.1-2001, and it is not available on all UNIX implementations.
 * Before kernel 2.6.21, mincore() did not return correct information some mappings.
+
+The cachestat syscall was only added to the Linux kernel in 6.5 and is currently only 
+supported on x86_64.
 
 ## Author
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/tobert/pcstat
 
-go 1.17
+go 1.18
 
-require golang.org/x/sys v0.10.0
+require golang.org/x/sys v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ var (
 	pidFlag                                     int
 	terseFlag, nohdrFlag, jsonFlag, unicodeFlag bool
 	plainFlag, ppsFlag, histoFlag, bnameFlag    bool
-	sortFlag bool
+	sortFlag, cachestatFlag                     bool
 )
 
 func init() {
@@ -54,6 +54,7 @@ func init() {
 	flag.BoolVar(&histoFlag, "histo", false, "print a simple histogram instead of raw data")
 	flag.BoolVar(&bnameFlag, "bname", false, "convert paths to basename to narrow the output")
 	flag.BoolVar(&sortFlag, "sort", false, "sort output by cached pages desc")
+	flag.BoolVar(&cachestatFlag, "cachestat", false, "use cachestat syscall (kernel 6.5+ only)")
 }
 
 func main() {
@@ -76,7 +77,7 @@ func main() {
 
 	stats := make(PcStatusList, 0, len(files))
 	for _, fname := range files {
-		status, err := pcstat.GetPcStatus(fname)
+		status, err := pcstat.GetPcStatus(fname, cachestatFlag)
 		if err != nil {
 			log.Printf("skipping %q: %v", fname, err)
 			continue

--- a/pkg/cachestat.go
+++ b/pkg/cachestat.go
@@ -1,0 +1,37 @@
+package pcstat
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// FileCachestat uses the cachestat syscall to get the
+// number of cached pages for the file without using '
+// an intermediate per-page bool map. It then returns
+// it alongside the numberof total pages
+func FileCachestat(f *os.File, size int64) (int, int, error) {
+	//skip could not mmap error when the file size is 0
+	if int(size) == 0 {
+		return 0, 0,nil
+	}
+
+	pcount := int((size + int64(os.Getpagesize()) - 1) / int64(os.Getpagesize()))
+
+	// Use cachestat syscall
+	crange := &unix.CachestatRange{
+		Off: 0,
+		Len: uint64(size),
+	}
+	cstat := &unix.Cachestat_t{}
+	err := unix.Cachestat(uint(f.Fd()), crange, cstat, 0)
+	if err != nil {
+		return 0, 0, fmt.Errorf("cachestat syscall failed: %v", err)
+	}
+
+	cached := cstat.Cache + cstat.Dirty + cstat.Writeback
+
+	return int(cached), pcount, nil
+}
+

--- a/pkg/cachestat.go
+++ b/pkg/cachestat.go
@@ -11,10 +11,10 @@ import (
 // number of cached pages for the file without using '
 // an intermediate per-page bool map. It then returns
 // it alongside the numberof total pages
-func FileCachestat(f *os.File, size int64) (int, int, error) {
+func FileCachestat(f *os.File, size int64) (*unix.Cachestat_t, int, error) {
 	//skip could not mmap error when the file size is 0
 	if int(size) == 0 {
-		return 0, 0,nil
+		return nil, 0, nil
 	}
 
 	pcount := int((size + int64(os.Getpagesize()) - 1) / int64(os.Getpagesize()))
@@ -27,11 +27,9 @@ func FileCachestat(f *os.File, size int64) (int, int, error) {
 	cstat := &unix.Cachestat_t{}
 	err := unix.Cachestat(uint(f.Fd()), crange, cstat, 0)
 	if err != nil {
-		return 0, 0, fmt.Errorf("cachestat syscall failed: %v", err)
+		return nil, 0, fmt.Errorf("cachestat syscall failed: %v", err)
 	}
 
-	cached := cstat.Cache + cstat.Dirty + cstat.Writeback
-
-	return int(cached), pcount, nil
+	return cstat, pcount, nil
 }
 

--- a/pkg/pcstatus.go
+++ b/pkg/pcstatus.go
@@ -85,7 +85,7 @@ func GetPcStatus(fname string, useCachestat bool) (PcStatus, error) {
 		pcs.RecentlyEvicted = cstat.Recently_evicted
 
 		// default for backward compatibility with mincore impl
-		pcs.Cached = int(cstat.Cache + cstat.Dirty + cstat.Writeback)
+		pcs.Cached = int(cstat.Cache)
 		pcs.Pages = psize
 	} else {
 

--- a/pkg/pcstatus.go
+++ b/pkg/pcstatus.go
@@ -37,11 +37,10 @@ type PcStatus struct {
 	Percent   float64   `json:"percent"`   // percentage of pages cached
 	PPStat    []bool    `json:"status"`    // per-page status, true if cached, false otherwise
 	// additional fields for cachestat implementation
-	CachedOnly      uint64 `json:"ccached,omitempty"`          // number of pages that are cached but not dirty or writeback
-	Dirty           uint64 `json:"dirty,omitempty"`            // number of dirty pages
-	Writeback       uint64 `json:"writeback,omitempty"`        // number of pages under writeback
-	Evicted         uint64 `json:"evicted,omitempty"`          // number of evicted pages
-	RecentlyEvicted uint64 `json:"recently_evicted,omitempty"` // number of recently evicted pages
+	Dirty           *uint64 `json:"dirty,omitempty"`            // number of dirty pages
+	Writeback       *uint64 `json:"writeback,omitempty"`        // number of pages under writeback
+	Evicted         *uint64 `json:"evicted,omitempty"`          // number of evicted pages
+	RecentlyEvicted *uint64 `json:"recently_evicted,omitempty"` // number of recently evicted pages
 }
 
 func GetPcStatus(fname string, useCachestat bool) (PcStatus, error) {
@@ -78,11 +77,15 @@ func GetPcStatus(fname string, useCachestat bool) (PcStatus, error) {
 		}
 
 		// will be shown in json output only for now
-		pcs.CachedOnly = cstat.Cache
-		pcs.Dirty = cstat.Dirty
-		pcs.Writeback = cstat.Writeback
-		pcs.Evicted = cstat.Evicted
-		pcs.RecentlyEvicted = cstat.Recently_evicted
+		dirty := cstat.Dirty
+		writeback := cstat.Writeback
+		evicted := cstat.Evicted
+		recentlyEvicted := cstat.Recently_evicted
+
+		pcs.Dirty = &dirty
+		pcs.Writeback = &writeback
+		pcs.Evicted = &evicted
+		pcs.RecentlyEvicted = &recentlyEvicted
 
 		// default for backward compatibility with mincore impl
 		pcs.Cached = int(cstat.Cache)


### PR DESCRIPTION
This adds support for the cachestat syscall introduced in kernel 6.5 by @nhatsmrt as an alternative to mmap/mincore. I've tried to make sure that the output is fully backward-compatible and users have to explicitly opt-in to the mechanism. The only output that's changed is the `-json` output where I've added the newly available stats if and only `-cachestat` is chosen. 

There's some good background on the new syscall [here](https://lore.kernel.org/lkml/20230503013608.2431726-1-nphamcs@gmail.com/T/). I guess the headline is this:

> Using cachestat
> real -- Median: 33.377s, Average: 33.475s, Standard Deviation: 0.3602
> user -- Median: 4.08s, Average: 4.1078s, Standard Deviation: 0.0742
> sys -- Median: 28.823s, Average: 28.8866s, Standard Deviation: 0.2689
> 
> Using mincore:
> real -- Median: 102.352s, Average: 102.3442s, Standard Deviation: 0.2059
> user -- Median: 10.149s, Average: 10.1482s, Standard Deviation: 0.0162
> sys -- Median: 91.186s, Average: 91.2084s, Standard Deviation: 0.2046
> 
> I also ran both syscalls on a 2TB sparse file:
> 
> Using cachestat:
> real    0m0.009s
> user    0m0.000s
> sys     0m0.009s
> 
> Using mincore:
> real    0m37.510s
> user    0m2.934s
> sys     0m34.558s

I'm going to run some more tests over the next few days, but it looks like 15GB ish is the sweet spot where the new syscall starts to make a difference.